### PR TITLE
M-2756 iOS, photo crop menu: Instrument panel is positioned too close to the bottom screen border

### DIFF
--- a/RNImageCropPicker.podspec
+++ b/RNImageCropPicker.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "8.0"
   s.dependency 'React-Core'
   s.dependency 'React-RCTImage'
-  s.dependency 'TOCropViewController', '~> 2.7.4'
+  s.dependency 'TOCropViewController', :git => 'https://github.com/sharekey/TOCropViewController', :commit => '6d23186523e99b980fb42bdead7b44649b6ce865'
   s.resource_bundles = {
     'RNImageCropPickerPrivacyInfo' => ['ios/PrivacyInfo.xcprivacy'],
   }

--- a/RNImageCropPicker.podspec
+++ b/RNImageCropPicker.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "8.0"
   s.dependency 'React-Core'
   s.dependency 'React-RCTImage'
-  s.dependency 'TOCropViewController', :git => 'https://github.com/sharekey/TOCropViewController', :commit => '6d23186523e99b980fb42bdead7b44649b6ce865'
+  s.dependency 'TOCropViewController'
   s.resource_bundles = {
     'RNImageCropPickerPrivacyInfo' => ['ios/PrivacyInfo.xcprivacy'],
   }


### PR DESCRIPTION
[M-2756](https://yt.sharekey.com/issue/M-2756) iOS, photo crop menu: Instrument panel is positioned too close to the bottom screen border

Fix cropper denpendency